### PR TITLE
Fix typos and improve clarity in multiple documents

### DIFF
--- a/hardware/hardware-requirements.md
+++ b/hardware/hardware-requirements.md
@@ -102,7 +102,7 @@ Enterprise servers are jam packed with features, and are specifically designed t
 
 **Price:** Medium price
 
-**Performance:** The DAppNodeXtreme is a good option if you are looking for a custom built OS with an easy UX. A DAppNode box is just a NUC pre-configured with their software. If you are confident enough to install an OS by yourself, you can save a bit of money by purchasing a normal NUC and installing DAppNode yourself. You can also install the DAppNode OS on any computer. If you don’t want to mess around with installing operating systems and want an easy UX, buying a DAppNode box is a convenient and simple way to get started.
+**Performance:** The DAppNodeXtreme is a good option if you are looking for a custom-built OS with an easy UX. A DAppNode box is just a NUC pre-configured with their software. If you are confident enough to install an OS by yourself, you can save a bit of money by purchasing a normal NUC and installing DAppNode yourself. You can also install the DAppNode OS on any computer. If you don’t want to mess around with installing operating systems and want an easy UX, buying a DAppNode box is a convenient and simple way to get started.
 
 **Power Usage:** 20-25ish watts.
 

--- a/help/missed-attestations.md
+++ b/help/missed-attestations.md
@@ -16,7 +16,7 @@ To go on a deep dive and learn everything about the attestation duty, timings, e
 - [Exploring ETH2: Attestation Inclusion ↗](https://www.symphonious.net/2020/09/08/exploring-eth2-attestation-inclusion/) by Adrian Sutton
 - [Defining Attestation Effectiveness ↗](https://www.attestant.io/posts/defining-attestation-effectiveness/) by Jim McDonald
 
-As a staker, you cannot do much about the causes that are outside of your control. What you can do is work on elements of your setup that are under your control to maximize your rewards. Even if you have a setup that was performing well before the merge, it's possible that with the additional work being introduced, some overlooked part of your setup might be the cause of additional misses or lower effectiveness since the merge happened. That's why you should double check all these items.
+As a staker, you cannot do much about the causes that are outside of your control. What you can do is work on elements of your setup that are under your control to maximize your rewards. Even if you have a setup that was performing well before the merge, it's possible that with the additional work being introduced, some overlooked part of your setup might be the cause of additional misses or lower effectiveness since the merge happened. That's why you should double-check all these items.
 
 1. Make sure your clients are _up-to-date_. Client updates often include optimizations and improvements that will help perform your duties on time.
 

--- a/help/missed-attestations.md
+++ b/help/missed-attestations.md
@@ -20,7 +20,7 @@ As a staker, you cannot do much about the causes that are outside of your contro
 
 1. Make sure your clients are _up-to-date_. Client updates often include optimizations and improvements that will help perform your duties on time.
 
-2. Make sure your machine consistently has enough _resources_ (CPU, RAM, disk, etc). Using a dedicated machine can help. If your clients are starved of any of these resources, it will likely be a cause for more misses and lower effectiveness.
+2. Make sure your machine consistently has enough _resources_ (CPU, RAM, disk, etc). Using a dedicated machine can help. If your clients are starved of these resources, it will likely be a cause for more misses and lower effectiveness.
 
 3. Make sure your _time_ is properly in sync. The beacon chain protocol is quite time sensitive. chrony is a good tool to improve your time sync. On Ubuntu or Debian derivatives, installing chrony is often as easy as `sudo apt install chrony`. On Windows, you can use [these instructions ↗](https://www.reddit.com/r/ethstaker/comments/nfca22/an_opiniated_solution_to_improve_time_sync_on/) to improve your time sync.
 

--- a/networking/setting-up-tailscale-vpn.md
+++ b/networking/setting-up-tailscale-vpn.md
@@ -18,7 +18,7 @@ We will briefly cover a basic configuration of it, but feel free to [review thei
 
 First, create a free [Tailscale account ↗](https://tailscale.com/). Tailscale requires the use of an SSO identity provider such as Google, GitHub, Okta, Microsoft, etc. For details, visit [their SSO Page ↗](https://tailscale.com/kb/1013/sso-providers/).
 
-It is recommended that you enable 2FA (Two Factor Authentication) on whichever identity provider you choose for added security.
+It is recommended that you enable 2FA (Two-Factor Authentication) on whichever identity provider you choose for added security.
 
 Next, follow [their onboarding guide ↗](https://tailscale.com/kb/1017/install/) to install Tailscale on your **client** - the machine you want to connect to your network with. For example, this could be a laptop or your phone. **Note that it is **_**not**_** your validator node!**
 

--- a/scaled-node-operators/updates-at-scale.md
+++ b/scaled-node-operators/updates-at-scale.md
@@ -59,7 +59,7 @@ Alternatively, you can develop a custom bot tailored to your requirements for tr
 
 Proper planning is crucial for the smooth execution of software upgrades. By incorporating software upgrade planning into your project management process, you can ensure timely implementation, address the risk of de-prioritization, and mitigate potential technical issues due to more time to research and prepare.
 
-* Ensure that all important data is backed up in advanced. Have a detailed, repeatable process for this. A backup is only truly a backup if you are actually able to restore it, so make sure to test the full end to end process, not just to assume that if you too a backup that it will work.
+* Ensure that all important data is backed up in advanced. Have a detailed, repeatable process for this. A backup is only truly a backup if you are actually able to restore it, so make sure to test the full end-to-end process, not just to assume that if you too a backup that it will work.
 * Make sure you talk about software upgrades in the planning session: For example, if your team uses Scrum and conducts planning every two weeks, allocate 20 minutes just to go through all the software new releases. This practice will help ensure that upgrades are prioritized and completed within the designated time frame.
 * Check for deadlines and breaking changes: When you go through the releases, make sure you check for any deadlines associated with software upgrades, such as hard forks or security patches, and plan accordingly. Also, examine the release notes for breaking changes that may require additional work or adjustments to your existing configurations. Keep in mind that some changes, like database upgrades, might be irreversible and must be rolled out with care.
 


### PR DESCRIPTION
This pull request addresses various typos and clarity improvements across multiple documents:

1. Fixed spelling of "custom built" to "custom-built" in `hardware-requirements.md`.
2. Corrected "double check" to "double-check" in `missed-attestations.md`.
3. Replaced "starved of any of these resources" with "starved of these resources" in `missed-attestations.md`.
4. Corrected "Two Factor Authentication" to "Two-Factor Authentication" in `setting-up-tailscale-vpn.md`.
5. Added hyphens to "end to end" to "end-to-end" in `updates-at-scale.md`.

Changes ensure proper grammar and terminology usage in technical documents.
