### PR TITLE
Fix for new repo org

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -94,7 +94,7 @@ You can earn GitPOAPs by contributing directly to the EthStaker Knowledge Base (
 
 [![EthStaker Knowledge Base Contributor GitPOAP 2023](https://www.gitpoap.io/\_next/image?url=https%3A%2F%2Fassets.poap.xyz%2Fgitpoap3a-2023-ethstaker-knowledge-base-contributor-2022-logo-1671596764627.png\&w=384\&q=75)](https://www.gitpoap.io/gp/881)[![EthStaker Knowledge Base Supporter GitPOAP 2023](https://www.gitpoap.io/\_next/image?url=https%3A%2F%2Fassets.poap.xyz%2F2023-ethstaker-knowledge-base-supporter-2022-logo-1672411990803.png\&w=384\&q=75)](https://www.gitpoap.io/gp/923)
 
-To suggest changes or add new content please visit our [EthStaker Github↗](https://github.com/eth-educators/ethstaker-knowledgebase) or if you have any questions please join our [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS).&#x20;
+To suggest changes or add new content please visit our [EthStaker Github↗](https://github.com/ethstaker/ethstaker-knowledgebase) or if you have any questions please join our [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS).&#x20;
 
 ### ✏️ Get Involved
 

--- a/docs/en/get-involved/how-to-contribute.md
+++ b/docs/en/get-involved/how-to-contribute.md
@@ -12,7 +12,7 @@ You can earn GitPOAPs by contributing directly to the EthStaker Knowledge Base (
 
 [![EthStaker Knowledge Base Contributor GitPOAP 2023](https://www.gitpoap.io/_next/image?url=https%3A%2F%2Fassets.poap.xyz%2Fgitpoap3a-2023-ethstaker-knowledge-base-contributor-2022-logo-1671596764627.png&w=750&q=75)](https://www.gitpoap.io/gp/881)[![EthStaker Knowledge Base Supporter GitPOAP 2023](https://www.gitpoap.io/_next/image?url=https%3A%2F%2Fassets.poap.xyz%2F2023-ethstaker-knowledge-base-supporter-2022-logo-1672411990803.png&w=750&q=75)](https://www.gitpoap.io/gp/923)
 
-To suggest changes or add new content please visit our [EthStaker Github↗](https://github.com/eth-educators/ethstaker-knowledgebase) or if you have any questions please join our [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS).&#x20;
+To suggest changes or add new content please visit our [EthStaker Github↗](https://github.com/ethstaker/ethstaker-knowledgebase) or if you have any questions please join our [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS).&#x20;
 
 Please create a pull request for any changes you want to make and we'll review it as soon as possible.
 

--- a/docs/en/guides/MEV-relay-list.md
+++ b/docs/en/guides/MEV-relay-list.md
@@ -75,4 +75,4 @@ Selecting your relays **can be an important decision** for some stakers. You sho
 
 # Configuring MEV boost software
 
-If you need help installing and configuring mev-boost on your machine, check out our [Guide on how to prepare a staking machine for the Merge](https://github.com/eth-educators/ethstaker-guides/blob/main/docs/prepare-for-the-merge.md#choosing-and-configuring-an-mev-solution)
+If you need help installing and configuring mev-boost on your machine, check out our [Guide on how to prepare a staking machine for the Merge](https://docs.ethstaker.org/guides/legacy-guides/prepare-for-the-merge)

--- a/docs/en/guides/hoodi-testnet/hoodi-nethermind-lighthouse.md
+++ b/docs/en/guides/hoodi-testnet/hoodi-nethermind-lighthouse.md
@@ -225,7 +225,7 @@ Requesting or obtaining enough Hoodi ETH to perform your validator deposit can b
 There are 2 great tools to create your validator keys:
 
 * GUI based: [Wagyu Key Gen](https://github.com/stake-house/wagyu-key-gen)
-* CLI based: [ethstaker-deposit-cli](https://github.com/eth-educators/ethstaker-deposit-cli)
+* CLI based: [ethstaker-deposit-cli](https://github.com/ethstaker/ethstaker-deposit-cli)
 
 If you choose the *Wagyu Key Gen* application, make sure to select the *Hoodi* network and follow the instructions provided. If you are using the #cheap-hoodi-validator process, you will need to use `0x4D496CcC28058B1D74B7a19541663E21154f9c84` as your withdrawal address. This is only required for that process. When on Mainnet, you should use a withdrawal address you control if you want to use one.
 
@@ -233,7 +233,7 @@ If you choose the *ethstaker-deposit-cli* application, here is how to create you
 
 ```console
 $ cd ~
-$ wget https://github.com/eth-educators/ethstaker-deposit-cli/releases/download/v1.1.0/ethstaker_deposit-cli-08f1e66-linux-amd64.tar.gz
+$ wget https://github.com/ethstaker/ethstaker-deposit-cli/releases/download/v1.1.0/ethstaker_deposit-cli-08f1e66-linux-amd64.tar.gz
 $ tar xvf ethstaker_deposit-cli-08f1e66-linux-amd64.tar.gz
 $ rm ethstaker_deposit-cli-08f1e66-linux-amd64.tar.gz
 $ cd ethstaker_deposit-cli-08f1e66-linux-amd64/

--- a/docs/en/guides/hoodi-testnet/hoodi-reth-lodestar.md
+++ b/docs/en/guides/hoodi-testnet/hoodi-reth-lodestar.md
@@ -221,7 +221,7 @@ Requesting or obtaining enough Hoodi ETH to perform your validator deposit can b
 There are 2 great tools to create your validator keys:
 
 * GUI based: [Wagyu Key Gen](https://github.com/stake-house/wagyu-key-gen)
-* CLI based: [ethstaker-deposit-cli](https://github.com/eth-educators/ethstaker-deposit-cli)
+* CLI based: [ethstaker-deposit-cli](https://github.com/ethstaker/ethstaker-deposit-cli)
 
 If you choose the *Wagyu Key Gen* application, make sure to select the *Hoodi* network and follow the instructions provided. If you are using the #cheap-hoodi-validator process, you will need to use `0x4D496CcC28058B1D74B7a19541663E21154f9c84` as your withdrawal address. This is only required for that process. When on Mainnet, you should use a withdrawal address you control if you want to use one.
 
@@ -229,7 +229,7 @@ If you choose the *ethstaker-deposit-cli* application, here is how to create you
 
 ```console
 $ cd ~
-$ wget https://github.com/eth-educators/ethstaker-deposit-cli/releases/download/v1.1.0/ethstaker_deposit-cli-08f1e66-linux-amd64.tar.gz
+$ wget https://github.com/ethstaker/ethstaker-deposit-cli/releases/download/v1.1.0/ethstaker_deposit-cli-08f1e66-linux-amd64.tar.gz
 $ tar xvf ethstaker_deposit-cli-08f1e66-linux-amd64.tar.gz
 $ rm ethstaker_deposit-cli-08f1e66-linux-amd64.tar.gz
 $ cd ethstaker_deposit-cli-08f1e66-linux-amd64/

--- a/docs/en/guides/monitoring-maintenance/alerting.md
+++ b/docs/en/guides/monitoring-maintenance/alerting.md
@@ -426,7 +426,7 @@ I created a simple script to ease the pain of updating Alertmanager. You can fin
 You can easily download this script with:
 
 ```console
-$ wget https://raw.githubusercontent.com/eth-educators/ethstaker-guides/main/docs/scripts/update-alertmanager.py
+$ wget https://docs.ethstaker.org/assets/scripts/update-alertmanager.py
 ```
 
 To run the Alertmanager update script, use this command:

--- a/docs/en/guides/monitoring-maintenance/monitoring.md
+++ b/docs/en/guides/monitoring-maintenance/monitoring.md
@@ -516,7 +516,7 @@ Aug 09 12:34:05 remy-MINIPC-PN50 systemd[1]: Reloaded Prometheus.
 Aug 09 12:34:05 remy-MINIPC-PN50 prometheus[1934]: level=info ts=2021-08-09T16:34:05.304Z caller=main.go:981 msg="Loading configuration file" filename=/etc/prometheus/prometheus.yml
 Aug 09 12:34:05 remy-MINIPC-PN50 prometheus[1934]: level=info ts=2021-08-09T16:34:05.311Z caller=main.go:1012 msg="Completed loading of configuration file" filename=/etc/prometheus/prometheus.yml totalDuration=7.822144ms remote_storage=4.305µs web_handler=6.249µs query_engine=1.734µs scrape=1.831998ms scrape_sd=83.865µs notify=618.619µs notify_sd=51.754µs rules=1.993µs
 ```
-3. Import [a good Geth dashboard for Prometheus](https://raw.githubusercontent.com/eth-educators/ethstaker-guides/main/docs/dashboards/geth-grafana.json) in Grafana.
+3. Import [a good Geth dashboard for Prometheus](https://raw.githubusercontent.com/ethstaker/ethstaker-guides/main/docs/dashboards/geth-grafana.json) in Grafana.
 
 ### Prysm
 
@@ -726,8 +726,8 @@ I created some simple scripts to ease the pain of updating Prometheus and Node E
 You can easily download those scripts with:
 
 ```console
-$ wget https://raw.githubusercontent.com/eth-educators/ethstaker-guides/main/docs/scripts/update-prometheus.py
-$ wget https://raw.githubusercontent.com/eth-educators/ethstaker-guides/main/docs/scripts/update-node-exporter.py
+$ wget https://docs.ethstaker.org/assets/scripts/update-prometheus.py
+$ wget https://docs.ethstaker.org/assets/scripts/update-node-exporter.py
 ```
 
 To run the Prometheus update script, use this command:

--- a/docs/en/tutorials/updating-withdrawal-credentials.md
+++ b/docs/en/tutorials/updating-withdrawal-credentials.md
@@ -6,7 +6,7 @@ It is possible upon validator creation to specify a withdrawal address and, if y
 
 **Please note**: If at any point you are confused as to what to do, please ask the EthStaker community for guidance. There are no stupid questions and we always strive to be welcoming first and knowledgeable second.
 
-**eth-docker users:** There is a standalone guide if you use eth-docker [here](https://github.com/eth-educators/eth-docker/tree/main/.eth/ethdo). The following guide can be considered a companion as the steps are very similar.
+**eth-docker users:** There is a standalone guide if you use eth-docker [here](https://github.com/ethstaker/eth-docker/tree/main/.eth/ethdo). The following guide can be considered a companion as the steps are very similar.
 
 ## Warnings
 

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -56,7 +56,7 @@ Puedes ganar GitPOAPs contribuyendo directamente a la Base de Conocimientos de E
 
 [![EthStaker Knowledge Base Contributor GitPOAP 2023](https://www.gitpoap.io/\_next/image?url=https%3A%2F%2Fassets.poap.xyz%2Fgitpoap3a-2023-ethstaker-knowledge-base-contributor-2022-logo-1671596764627.png\&w=384\&q=75)](https://www.gitpoap.io/gp/881)[![EthStaker Knowledge Base Supporter GitPOAP 2023](https://www.gitpoap.io/\_next/image?url=https%3A%2F%2Fassets.poap.xyz%2F2023-ethstaker-knowledge-base-supporter-2022-logo-1672411990803.png\&w=384\&q=75)](https://www.gitpoap.io/gp/923)
 
-Para sugerir cambios o añadir contenidos nuevos visita nuestro [EthStaker Github↗](https://github.com/eth-educators/ethstaker-knowledgebase)  o si tienes alguna pregunta únete a nuestro  [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS) en el canal en español.
+Para sugerir cambios o añadir contenidos nuevos visita nuestro [EthStaker Github↗](https://github.com/ethstaker/ethstaker-knowledgebase)  o si tienes alguna pregunta únete a nuestro  [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS) en el canal en español.
 
 ### ✏️ Involucrate
 

--- a/docs/es/get-involved/how-to-contribute.md
+++ b/docs/es/get-involved/how-to-contribute.md
@@ -12,7 +12,7 @@ Puedes ganar GitPOAPs contribuyendo directamente a la Base de conocimiento de Et
 
 [![EthStaker Knowledge Base Contributor GitPOAP 2023](https://www.gitpoap.io/\_next/image?url=https%3A%2F%2Fassets.poap.xyz%2Fgitpoap3a-2023-ethstaker-knowledge-base-contributor-2022-logo-1671596764627.png\&w=384\&q=75)](https://www.gitpoap.io/gp/881)[![EthStaker Knowledge Base Supporter GitPOAP 2023](https://www.gitpoap.io/\_next/image?url=https%3A%2F%2Fassets.poap.xyz%2F2023-ethstaker-knowledge-base-supporter-2022-logo-1672411990803.png\&w=384\&q=75)](https://www.gitpoap.io/gp/923)
 
-Para sugerir cambios o agregar contenido nuevo, visita nuestro [EthStaker Github↗](https://github.com/eth-educators/ethstaker-knowledgebase) o si tienes alguna pregunta, únete a nuestro [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS)
+Para sugerir cambios o agregar contenido nuevo, visita nuestro [EthStaker Github↗](https://github.com/ethstaker/ethstaker-knowledgebase) o si tienes alguna pregunta, únete a nuestro [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS)
 
 Crea una solicitud para cualquier cambio que quieras realizar y lo revisaremos lo antes posible.
 

--- a/docs/es/tutorials/updating-withdrawal-credentials.md
+++ b/docs/es/tutorials/updating-withdrawal-credentials.md
@@ -12,7 +12,7 @@ Es posible durante la creación de un validador especificar una dirección de re
 
 Tenga en cuenta: Si en algún momento está confundido con qué debería hacer, pida orientación a la comunidad de EthStaker. No hay preguntas tontas y siempre nos esforzamos por dar la bienvenida a quien llegue antes de ayudarles.
 
-Usuarios de eth-docker: Hay una guía independiente si usas eth-docker[ aquí](https://github.com/eth-educators/eth-docker/tree/main/.eth/ethdo). La siguiente guía puede considerarse un complemento ya que los pasos son muy similares.
+Usuarios de eth-docker: Hay una guía independiente si usas eth-docker[ aquí](https://github.com/ethstaker/eth-docker/tree/main/.eth/ethdo). La siguiente guía puede considerarse un complemento ya que los pasos son muy similares.
 
 ## Advertencias
 

--- a/docs/ms/README.md
+++ b/docs/ms/README.md
@@ -53,7 +53,7 @@ Anda boleh peroleh GitPOAPs daripada menyumbang secara terus kepada Pengetahuan 
 
 [![EthStaker Knowledge Base Contributor GitPOAP 2023](https://www.gitpoap.io/\_next/image?url=https%3A%2F%2Fassets.poap.xyz%2Fgitpoap3a-2023-ethstaker-knowledge-base-contributor-2022-logo-1671596764627.png\&w=384\&q=75)](https://www.gitpoap.io/gp/881)[![EthStaker Knowledge Base Supporter GitPOAP 2023](https://www.gitpoap.io/\_next/image?url=https%3A%2F%2Fassets.poap.xyz%2F2023-ethstaker-knowledge-base-supporter-2022-logo-1672411990803.png\&w=384\&q=75)](https://www.gitpoap.io/gp/923)
 
-Untuk sebarang cadangan perubahan dan penambahan kandungan sila lawati [EthStaker Github↗](https://github.com/eth-educators/ethstaker-knowledgebase) atau mempunyai sebarang pertanyaan sila sertai [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS).&#x20;
+Untuk sebarang cadangan perubahan dan penambahan kandungan sila lawati [EthStaker Github↗](https://github.com/ethstaker/ethstaker-knowledgebase) atau mempunyai sebarang pertanyaan sila sertai [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS).&#x20;
 
 ### ✏️ Melibatkan diri
 

--- a/docs/pt/README.md
+++ b/docs/pt/README.md
@@ -55,7 +55,7 @@ Você pode ganhar GitPOAPs contribuindo diretamente para a Base de Conhecimento 
 
 [![EthStaker Knowledge Base Contributor GitPOAP 2023](https://www.gitpoap.io/\_next/image?url=https%3A%2F%2Fassets.poap.xyz%2Fgitpoap3a-2023-ethstaker-knowledge-base-contributor-2022-logo-1671596764627.png\&w=384\&q=75)](https://www.gitpoap.io/gp/881)[![EthStaker Knowledge Base Supporter GitPOAP 2023](https://www.gitpoap.io/\_next/image?url=https%3A%2F%2Fassets.poap.xyz%2F2023-ethstaker-knowledge-base-supporter-2022-logo-1672411990803.png\&w=384\&q=75)](https://www.gitpoap.io/gp/923)
 
-Para sugerir alterações ou adicionar novos conteúdos, visite nosso [Github↗ ](https://github.com/eth-educators/ethstaker-knowledgebase)ou, se tiver alguma dúvida, entre em nosso [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS).&#x20;
+Para sugerir alterações ou adicionar novos conteúdos, visite nosso [Github↗ ](https://github.com/ethstaker/ethstaker-knowledgebase)ou, se tiver alguma dúvida, entre em nosso [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS).&#x20;
 
 ### ✏️ Envolva-se
 

--- a/docs/pt/get-involved/how-to-contribute.md
+++ b/docs/pt/get-involved/how-to-contribute.md
@@ -6,7 +6,7 @@ Você pode ganhar GitPOAPs contribuindo diretamente para a Base de Conhecimento 
 
 [![EthStaker Knowledge Base Contributor GitPOAP 2023](https://www.gitpoap.io/\_next/image?url=https%3A%2F%2Fassets.poap.xyz%2Fgitpoap3a-2023-ethstaker-knowledge-base-contributor-2022-logo-1671596764627.png\&w=384\&q=75)](https://www.gitpoap.io/gp/881)[![EthStaker Knowledge Base Supporter GitPOAP 2023](https://www.gitpoap.io/\_next/image?url=https%3A%2F%2Fassets.poap.xyz%2F2023-ethstaker-knowledge-base-supporter-2022-logo-1672411990803.png\&w=384\&q=75)](https://www.gitpoap.io/gp/923)
 
-Para sugerir alterações ou adicionar novos conteúdos, visite nosso [EthStaker Github↗](https://github.com/eth-educators/ethstaker-knowledgebase) ou, se tiver alguma dúvida, entre em nosso [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS).&#x20;
+Para sugerir alterações ou adicionar novos conteúdos, visite nosso [EthStaker Github↗](https://github.com/ethstaker/ethstaker-knowledgebase) ou, se tiver alguma dúvida, entre em nosso [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS).&#x20;
 
 Favor criar uma solicitação de pull para qualquer alteração que você queira fazer e nós analisaremos o mais rápido possível.
 

--- a/docs/tr/README.md
+++ b/docs/tr/README.md
@@ -49,7 +49,7 @@ Doğrudan EthStaker Bilgi Bankasına katkıda bulunarak ([contributor↗](https:
 
 [![EthStaker Knowledge Base Contributor GitPOAP 2023](https://www.gitpoap.io/\_next/image?url=https%3A%2F%2Fassets.poap.xyz%2Fgitpoap3a-2023-ethstaker-knowledge-base-contributor-2022-logo-1671596764627.png\&w=384\&q=75)](https://www.gitpoap.io/gp/881)[![EthStaker Knowledge Base Supporter GitPOAP 2023](https://www.gitpoap.io/\_next/image?url=https%3A%2F%2Fassets.poap.xyz%2F2023-ethstaker-knowledge-base-supporter-2022-logo-1672411990803.png\&w=384\&q=75)](https://www.gitpoap.io/gp/923)
 
-Değişiklik teklifinde bulunmak veya yeni içerik eklemek için [EthStaker Github↗](https://github.com/eth-educators/ethstaker-knowledgebase) sayfamızı ziyaret edebilir, herhangi bir konuda soru sormak için [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS) sunucumuza katılabilirsiniz.
+Değişiklik teklifinde bulunmak veya yeni içerik eklemek için [EthStaker Github↗](https://github.com/ethstaker/ethstaker-knowledgebase) sayfamızı ziyaret edebilir, herhangi bir konuda soru sormak için [Discord↗](https://www.google.com/url?sa=t\&rct=j\&q=\&esrc=s\&source=web\&cd=\&cad=rja\&uact=8\&ved=2ahUKEwjpm6nC5K78AhUBi1wKHaxHCF8QFnoECAsQAQ\&url=https%3A%2F%2Fdiscord.com%2Finvite%2FucsTcA2wTq\&usg=AOvVaw0U61EK\_8NaT71SEZlw3aJS) sunucumuza katılabilirsiniz.
 
 ### ✏️ Aramıza Katılın
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,8 +77,8 @@ plugins:
         - locale: tr
           name: Turkish
           build: true
-repo_url: https://github.com/eth-educators/ethstaker-knowledgebase
-repo_name: eth-educators/ethstaker-knowledgebase
+repo_url: https://github.com/ethstaker/ethstaker-knowledgebase
+repo_name: ethstaker/ethstaker-knowledgebase
 edit_uri: edit/main/docs/
 extra:
   analytics:
@@ -89,7 +89,7 @@ extra:
     - icon: fontawesome/brands/discord
       link: https://dsc.gg/ethstaker
     - icon: fontawesome/brands/github
-      link: https://github.com/eth-educators
+      link: https://github.com/ethstaker
     - icon: fontawesome/brands/x-twitter
       link: https://x.com/ethstaker
 extra_css:


### PR DESCRIPTION
Update reference to the old Github repo org to use the new one. Minor fixes for dead links.