### PR TITLE
fix: correct regex pattern for JPEG file extensions in main.html

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -26,7 +26,7 @@ function updateLinkTargets() {
       link.target = '_self';
     }
     // open all .pdf, .png, .jpg, .mp4 in new tab
-    if (/(\.pdf$|\.png$|\.jpe*g$|\.mp4)/.test(href)) {
+    if (/(\.pdf$|\.png$|\.jpe?g$|\.mp4)/.test(href)) {
       link.target = '_blank';
     }
     // if new-tab class, use new tab

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -24,7 +24,7 @@
             link.target = "_self";
           }
           // open all .pdf, .png, .jpg, .mp4 in new tab
-          if (/(\.pdf$|\.png$|\.jpe*g$|\.mp4)/.test(targetUrl)) {
+          if (/(\.pdf$|\.png$|\.jpe?g$|\.mp4)/.test(targetUrl)) {
             link.target = "_blank";
           }
         } catch (error) {


### PR DESCRIPTION
Replace `.jpe*g$` with `.jpe?g$` to properly match only standard JPEG extensions (.jpg and .jpeg)